### PR TITLE
Remove duplicate link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ _CEO and Executive Director of HCL Corporation_
 12. [Best Websites for Programmers](https://github.com/sdmg15/Best-websites-a-programmer-should-visit) :computer:
 13. [Competitive Coding Resources](https://github.com/Ashishgup1/Competitive-Coding) :gem:
 14. [SDE Interview Questions](https://github.com/rishabh115/SDE-Interview-Questions) :rocket:
-15. [CS Degree in a repo](https://github.com/ossu/computer-science)
 
 **Also check out the [GitHub README Project](https://github.com/readme) for some amazing and inspiring stories!**
 


### PR DESCRIPTION
## Description

Duplicate links (10 & 15) in "Other Helpful GitHub Repositories" section that both go to OSSU Repo.

Fixes 1

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My contribution follows the style guidelines of this project
- [X] I have performed a self-review of my own contribution
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
